### PR TITLE
Should compile now under glibc2

### DIFF
--- a/wand2.c
+++ b/wand2.c
@@ -847,7 +847,7 @@ fsize(FILE *fp)
 {
 	struct stat sbuf;
 
-	fstat(fp, &sbuf);
+	fstat(fileno(fp), &sbuf);
 	return(sbuf.st_size);
 }
 

--- a/wand2.c
+++ b/wand2.c
@@ -308,7 +308,7 @@ char	*string;
         return(cp - string);
 }
 
-in				       /* put wrd vals in w[0], w[1],  ... */
+int				       /* put wrd vals in w[0], w[1],  ... */
 wdparse(string, w, nums, flag)            /* if flag != 0 add to wrds list */
 char	*string;                 /* if flag == 0 (user inp) put #s in nums */
 int	w[], nums[];                              /* and return # of words */
@@ -847,7 +847,7 @@ fsize(FILE *fp)
 {
 	struct stat sbuf;
 
-	fstat(fp->_file, &sbuf);
+	fstat(fp, &sbuf);
 	return(sbuf.st_size);
 }
 


### PR DESCRIPTION
As-is, the source in this repository wouldn't compile under regular Linux (Tested in Ubuntu Vivid). This one-line patch fixes that (As well as the missing 't' in 'int' earlier in the file which is still present for some reason?).

Someone else will need to test this on OS X and figure it out; it may be the case that some platform-specific IFDEFs are needed. Note that this will hopefully also allow compilation in Windows under Cygwin.
