### PR TITLE
Add CFLAGS to support GCC 10 or later

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ CASTLE	= castle.misc castle.wrld
 LIBRARY	= library.misc library.wrld
 TUT	= tut.misc tut.wrld
 EXPORT	= Makefile $(DOCS) wanddef.h $(DOT_CS) $(A3) $(CASTLE) $(LIBRARY) $(TUT)
+CFLAGS	= -fcommon
 
 default: wander
 


### PR DESCRIPTION
In GCC version 10, the default behaviour is now `-fno-common`, as noted by Quill author Tim Gilberts when he co-hosted [The Retro Adventurers podcast episode on Aldebaran III](https://retroadventurers.podbean.com/e/38/).  The older flag is required to permit `wander` to compile under GCC on modern systems.